### PR TITLE
Fix Day 25 deploy setting filename mismatch

### DIFF
--- a/25-deploy-to-ubuntu-server.md
+++ b/25-deploy-to-ubuntu-server.md
@@ -13,7 +13,7 @@
 首先我們建立一個設定檔：
 
 ```python
-# lunch/settings/production_ubuntu.py
+# lunch/settings/deploy_ubuntu.py
 
 from .base import *
 


### PR DESCRIPTION
之後都是用 `deploy_ubuntu.py` ；也配合前面 heroku 的檔案樣式。