### PR TITLE
Add missing import

### DIFF
--- a/11-view-refactoring.md
+++ b/11-view-refactoring.md
@@ -87,6 +87,11 @@ def home(request):
 ```python
 url(r'^store/', include('stores.urls')),
 ```
+要記得在 `lunch/urls.py` 的開頭 import `include`
+
+```python
+from django.conf.urls import url
+```
 
 這代表「如果網址以 `store/` 開頭（注意 pattern 後面沒有 `$`），嘗試從 `stores.urls` 尋找符合項目」。
 

--- a/11-view-refactoring.md
+++ b/11-view-refactoring.md
@@ -90,7 +90,7 @@ url(r'^store/', include('stores.urls')),
 要記得在 `lunch/urls.py` 的開頭 import `include`
 
 ```python
-from django.conf.urls import url
+from django.conf.urls import include
 ```
 
 這代表「如果網址以 `store/` 開頭（注意 pattern 後面沒有 `$`），嘗試從 `stores.urls` 尋找符合項目」。

--- a/11-view-refactoring.md
+++ b/11-view-refactoring.md
@@ -87,10 +87,11 @@ def home(request):
 ```python
 url(r'^store/', include('stores.urls')),
 ```
-要記得在 `lunch/urls.py` 的開頭 import `include`
+
+請確認在 `lunch/urls.py` 的開頭有 import `include`
 
 ```python
-from django.conf.urls import include
+from django.conf.urls import url, include
 ```
 
 這代表「如果網址以 `store/` 開頭（注意 pattern 後面沒有 `$`），嘗試從 `stores.urls` 尋找符合項目」。


### PR DESCRIPTION
If I follow the instruction to add the url rule (`url(r'^store/', include('stores.urls')),`) and run test, the test would tell it does not know how `include` it is. Just import `include` function to resolve the problem.